### PR TITLE
add bigemoji style

### DIFF
--- a/app/javascript/styles/bigemoji.scss
+++ b/app/javascript/styles/bigemoji.scss
@@ -1,0 +1,3 @@
+@import 'bigemoji/variables';
+@import 'application';
+@import 'bigemoji/diff';

--- a/app/javascript/styles/bigemoji/diff.scss
+++ b/app/javascript/styles/bigemoji/diff.scss
@@ -1,0 +1,58 @@
+$emoji-enlarge-time: 40ms;
+
+// bigger emojis
+.status__content,
+.detailed-status .status__content,
+.account__header__bio {
+  .emojione {
+    --emoji-size: 1.5em;
+    width: var(--emoji-size, 36px);
+    height: var(--emoji-size, 36px);
+    font-size: var(--emoji-size, 36px);
+    transition: transform $emoji-enlarge-time ease;
+    
+    &:hover {
+        transform: scale(2);
+    }
+  }
+}
+
+
+// enlarge only (names)
+.display-name,
+.notification__display-name,
+.account__header__tabs__name {
+  .emojione {
+    transition: transform $emoji-enlarge-time linear;
+    vertical-align: center;
+
+    &:hover {
+      transform: scale(2);
+    }
+  }
+  
+}
+
+
+// don't crop enlarged emojis as possible
+.status__info {
+  .status__display-name, .display-name {
+    overflow-x: hidden;
+    overflow-y: visible;
+  }
+}
+
+
+// special case: collapsed article
+.status__content  {
+  overflow: visible;
+  &.status__content--collapsed {
+    overflow-y: hidden; // poor man's solution
+  }
+}
+
+
+// visual modifications
+.status__info {
+  align-items: flex-start;  // align time info to top (visual satisfaction)
+}

--- a/app/javascript/styles/bigemoji/variables.scss
+++ b/app/javascript/styles/bigemoji/variables.scss
@@ -1,0 +1,1 @@
+// intentionally empty

--- a/config/themes.yml
+++ b/config/themes.yml
@@ -8,3 +8,5 @@ twvariant-wide-extra: styles/twvariant-wide-extra.scss
 goyang:  styles/goyang.scss
 myeongjo:  styles/myeongjo.scss
 myeongjo_kronly:  styles/myeongjo_kronly.scss
+
+bigemoji: styles/bigemoji.scss


### PR DESCRIPTION
webapp 의 여러 페이지에서

- emoji 를 크게 보이게 하고
- 마우스를 올리면 더 커보이는

bigemoji 사이트 테마를 추가하는 PR입니다. 

- 가급적이면 마우스를 올렸을 때에 잘리지 않도록, overflow를 부분적으로라도 해지하도록 되어있습니다. (완벽하진 않지만요)
- 사소하지만 신경쓰이는 부분의 사소한 수정도 포함되어 있습니다. (status의 시간 표시 정렬 변경)
- 확대/축소 애니메이션은 제 취향을 반영하여 시간이 매우 짧게 설정되어 있습니다.

이 테마는 @ltlapy 님이 [제공해주셨던 소스](https://don.naru.cafe/@nyaa/109404019698423352) 를 기반으로 기존에 https://don.naru.cafe 에서 커스텀 css 로 설정하여 사용하던 것을 사이트 테마로 변경하면서 일부 내용을 보강한 버전입니다.